### PR TITLE
Fixed incorrect highlight of today's date

### DIFF
--- a/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarController.java
+++ b/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarController.java
@@ -510,6 +510,7 @@ class CompactCalendarController {
         //offset by one because of 0 index based calculations
         firstDayOfMonth = firstDayOfMonth - 1;
         boolean isSameMonthAsToday = monthToDrawCalender.get(Calendar.MONTH) == todayCalender.get(Calendar.MONTH);
+        boolean isSameYearAsToday = monthToDrawCalender.get(Calendar.YEAR) == todayCalender.get(Calendar.YEAR);
         boolean isSameMonthAsCurrentCalendar = monthToDrawCalender.get(Calendar.MONTH) == currentCalender.get(Calendar.MONTH);
         int todayDayOfMonth = todayCalender.get(Calendar.DAY_OF_MONTH);
 
@@ -534,7 +535,7 @@ class CompactCalendarController {
             } else {
                 int day = ((dayRow - 1) * 7 + dayColumn + 1) - firstDayOfMonth;
                 float yPosition = dayRow * heightPerDay + paddingHeight;
-                if (isSameMonthAsToday && todayDayOfMonth == day) {
+                if (isSameYearAsToday && isSameMonthAsToday && todayDayOfMonth == day) {
                     // TODO calculate position of circle in a more reliable way
                     drawCircle(canvas, xPosition, yPosition, currentDayBackgroundColor);
                 } else if (currentCalender.get(Calendar.DAY_OF_MONTH) == day && isSameMonthAsCurrentCalendar) {


### PR DESCRIPTION
To replicate, advance the date exactly one year ahead.  Note that "today's date" is highlighted - even though "today" was last year.