### PR TITLE
Don't select first day on month scroll - added property

### DIFF
--- a/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarController.java
+++ b/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarController.java
@@ -53,6 +53,7 @@ class CompactCalendarController {
     private int calenderTextColor;
     private int currentSelectedDayBackgroundColor;
     private int calenderBackgroundColor = Color.WHITE;
+    private boolean selectFirstDayOfMonthOnScroll = true;
     private int textSize = 30;
     private int width;
     private int height;
@@ -91,6 +92,7 @@ class CompactCalendarController {
                 calenderTextColor = typedArray.getColor(R.styleable.CompactCalendarView_compactCalendarTextColor, calenderTextColor);
                 currentSelectedDayBackgroundColor = typedArray.getColor(R.styleable.CompactCalendarView_compactCalendarCurrentSelectedDayBackgroundColor, currentSelectedDayBackgroundColor);
                 calenderBackgroundColor = typedArray.getColor(R.styleable.CompactCalendarView_compactCalendarBackgroundColor, calenderBackgroundColor);
+                selectFirstDayOfMonthOnScroll = typedArray.getBoolean(R.styleable.CompactCalendarView_compactCalendarSelectFirstDayOfMonthOnScroll, true);
                 textSize = typedArray.getDimensionPixelSize(R.styleable.CompactCalendarView_compactCalendarTextSize,
                         (int) TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, textSize, context.getResources().getDisplayMetrics()));
             } finally {
@@ -263,7 +265,7 @@ class CompactCalendarController {
                 currentDirection = Direction.NONE;
                 setCalenderToFirstDayOfMonth(calendarWithFirstDayOfMonth, currentDate, -monthsScrolledSoFar, 0);
 
-                if (calendarWithFirstDayOfMonth.get(Calendar.MONTH) != currentCalender.get(Calendar.MONTH)) {
+                if (selectFirstDayOfMonthOnScroll && calendarWithFirstDayOfMonth.get(Calendar.MONTH) != currentCalender.get(Calendar.MONTH)) {
                     setCalenderToFirstDayOfMonth(currentCalender, currentDate, -monthsScrolledSoFar, 0);
                 }
 
@@ -540,7 +542,7 @@ class CompactCalendarController {
                     drawCircle(canvas, xPosition, yPosition, currentDayBackgroundColor);
                 } else if (currentCalender.get(Calendar.DAY_OF_MONTH) == day && isSameMonthAsCurrentCalendar) {
                     drawCircle(canvas, xPosition, yPosition, currentSelectedDayBackgroundColor);
-                } else if (day == 1 && !isSameMonthAsCurrentCalendar) {
+                } else if (selectFirstDayOfMonthOnScroll && day == 1 && !isSameMonthAsCurrentCalendar) {
                     drawCircle(canvas, xPosition, yPosition, currentSelectedDayBackgroundColor);
                 }
                 if (day <= monthToDrawCalender.getActualMaximum(Calendar.DAY_OF_MONTH) && day > 0) {

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -3,6 +3,7 @@
     <declare-styleable name="CompactCalendarView">
         <attr name="compactCalendarTextSize" format="dimension"/>
         <attr name="compactCalendarBackgroundColor" format="color"/>
+        <attr name="compactCalendarSelectFirstDayOfMonthOnScroll" format="boolean"/>
         <attr name="compactCalendarCurrentDayBackgroundColor" format="color"/>
         <attr name="compactCalendarCurrentSelectedDayBackgroundColor" format="color"/>
         <attr name="compactCalendarTextColor" format="color"/>


### PR DESCRIPTION
Hi, this was bugging me for awhile, but I've added a new property (compactCalendarSelectFirstDayOfMonthOnScroll) which when set to false (by default it's true), won't automatically change the selected date to the first day of the newly selected month.