### PR TITLE
Handles scroll when inside a ViewPager or a vertical scroller

### DIFF
--- a/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarView.java
+++ b/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarView.java
@@ -62,12 +62,16 @@ public class CompactCalendarView extends View {
         @Override
         public boolean onScroll(MotionEvent e1, MotionEvent e2, float distanceX, float distanceY) {
             if(shouldScroll) {
-                compactCalendarController.onScroll(e1, e2, distanceX, distanceY);
-                invalidate();
-                return true;
-            } else {
-                return false;
+                if (Math.abs(distanceX) > 0) {
+                    getParent().requestDisallowInterceptTouchEvent(true);
+
+                    compactCalendarController.onScroll(e1, e2, distanceX, distanceY);
+                    invalidate();
+                    return true;
+                }
             }
+
+            return false;
         }
     };
 
@@ -367,6 +371,11 @@ public class CompactCalendarView extends View {
         if (shouldScroll) {
             compactCalendarController.onTouch(event);
             invalidate();
+        }
+
+        // on touch action finished (CANCEL or UP), we re-allow the parent container to intercept touch events (scroll inside ViewPager + RecyclerView issue #82)
+        if((event.getAction() == MotionEvent.ACTION_CANCEL || event.getAction() == MotionEvent.ACTION_UP) && shouldScroll) {
+            getParent().requestDisallowInterceptTouchEvent(false);
         }
 
         // always allow gestureDetector to detect onSingleTap and scroll events

--- a/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarView.java
+++ b/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarView.java
@@ -369,16 +369,14 @@ public class CompactCalendarView extends View {
             invalidate();
         }
 
-
-        // prevent parent container from processing ACTION_DOWN events (scroll inside ViewPager issue #82)
-        if(event.getAction() == MotionEvent.ACTION_DOWN && shouldScroll) {
-            getParent().requestDisallowInterceptTouchEvent(true);
-        } else if(event.getAction() == MotionEvent.ACTION_CANCEL && shouldScroll) {
-            getParent().requestDisallowInterceptTouchEvent(false);
-        }
-
         // always allow gestureDetector to detect onSingleTap and scroll events
         return gestureDetector.onTouchEvent(event);
+    }
+
+    @Override
+    public boolean canScrollHorizontally(int direction) {
+        // Prevents ViewPager from scrolling horizontally by announcing that (issue #82)
+        return true;
     }
 
 }


### PR DESCRIPTION
Copy/paste from my comment in #39 : 
"Hello,

I used your Calendar inside a RecyclerView and had the same issue. The fix you applied still prevents vertical scrolling if we're touching inside the CalendarView. The problem is that you're preventing the parent to intercept touch as soon as the CalendarView is touched, no matter if the touch is a simple click, a scroll (vertical or horizontal) or anything else.

To correct that, I've made 2 changes : 
1. For the horizontal scrolling, there is actually a method in View (that appeared in API 14) that sets if a given View can scroll horizontally and fortunately, the ViewPager reads it. We simply need to override the method "canScrollHorizontally" and return true : 
https://developer.android.com/reference/android/view/View.html#canScrollHorizontally(int)

For the vertical scrolling, I resolved it using the same trick you used for #82 but limited to a horizontal scroll : when I detect that the Calendar is scrolled horizontally, I prevent the parent to scroll. And I then re-allow it to intercept scrolling when the scroll is finished.
I'll open a Pull-Request with those modifications if you're interested in reviewing them."