### PR TITLE
improve CompatCalendarViewListener.onDayClick() response time.

### DIFF
--- a/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarController.java
+++ b/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarController.java
@@ -436,7 +436,7 @@ class CompactCalendarController {
         drawScrollableCalender(canvas);
     }
 
-    void onSingleTapConfirmed(MotionEvent e) {
+    void onSingleTapUp(MotionEvent e) {
         //Don't handle single tap the calendar is scrolling and is not stationary
         if (Math.abs(accumulatedScrollOffset.x) != Math.abs(width * monthsScrolledSoFar)) {
             return;

--- a/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarView.java
+++ b/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarView.java
@@ -43,10 +43,10 @@ public class CompactCalendarView extends View {
         }
 
         @Override
-        public boolean onSingleTapConfirmed(MotionEvent e) {
-            compactCalendarController.onSingleTapConfirmed(e);
+        public boolean onSingleTapUp(MotionEvent e) {
+            compactCalendarController.onSingleTapUp(e);
             invalidate();
-            return super.onSingleTapConfirmed(e);
+            return super.onSingleTapUp(e);
         }
 
         @Override


### PR DESCRIPTION
it felt laggy when clicking on the days in the calendar view because the  `OnGestureListener.onSingleTapConfirmed()` has triggered after a few milliseconds.

I propose to use `OnGestureListener. onSingleTapUp` instead of `OnGestureListener.onSingleTapConfirmed()`

