### PR TITLE
Add the third event to calendar before start to use plus sign

### DIFF
--- a/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarController.java
+++ b/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarController.java
@@ -778,8 +778,10 @@ class CompactCalendarController {
                             yPosition += indicatorOffset;
                         }
 
-                        if (eventsList.size() >= 3) {
+                        if (eventsList.size() >= 4) {
                             drawEventsWithPlus(canvas, xPosition, yPosition, eventsList);
+                        } else if (eventsList.size() == 3) {
+                            drawThreeEvents(canvas, xPosition, yPosition, eventsList);
                         } else if (eventsList.size() == 2) {
                             drawTwoEvents(canvas, xPosition, yPosition, eventsList);
                         } else if (eventsList.size() == 1) {
@@ -797,10 +799,19 @@ class CompactCalendarController {
     }
 
     private void drawTwoEvents(Canvas canvas, float xPosition, float yPosition, List<Event> eventsList) {
-        //draw fist event just left of center
+        //draw first event just left of center
         drawEventIndicatorCircle(canvas, xPosition + (xIndicatorOffset * -1), yPosition, eventsList.get(0).getColor());
         //draw second event just right of center
         drawEventIndicatorCircle(canvas, xPosition + (xIndicatorOffset * 1), yPosition, eventsList.get(1).getColor());
+    }
+
+    private void drawThreeEvents(Canvas canvas, float xPosition, float yPosition, List<Event> eventsList) {
+        //draw first event just left of center
+        drawEventIndicatorCircle(canvas, xPosition + (xIndicatorOffset * -2), yPosition, eventsList.get(0).getColor());
+        //draw second event centered
+        drawEventIndicatorCircle(canvas, xPosition, yPosition, eventsList.get(1).getColor());
+        //draw third event just right of center
+        drawEventIndicatorCircle(canvas, xPosition + (xIndicatorOffset * 2), yPosition, eventsList.get(2).getColor());
     }
 
     //draw 2 eventsByMonthAndYearMap followed by plus indicator to show there are more than 2 eventsByMonthAndYearMap


### PR DESCRIPTION
Considering that the calendar has room to draw up to three events for each day I would like to suggest the following pull request:

- if eventList.size() == 3 then draw the third event instead start to use the plus sign.
- if eventList.size() >= 4, draw the 1st and 2nd event and the plus sign.

Signed-off-by: Sergio Durand <sergiodurand@gmail.com>