### PR TITLE
Support for attrs in textColor

### DIFF
--- a/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarController.java
+++ b/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarController.java
@@ -1,6 +1,7 @@
 package com.github.sundeepk.compactcalendarview;
 
 import android.content.Context;
+import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
 import android.graphics.Canvas;
 import android.graphics.Color;
@@ -142,8 +143,21 @@ class CompactCalendarController {
         if (attrs != null && context != null) {
             TypedArray typedArray = context.getTheme().obtainStyledAttributes(attrs, R.styleable.CompactCalendarView, 0, 0);
             try {
+
+                int id = typedArray.getResourceId(R.styleable.CompactCalendarView_compactCalendarTextColor, -1);
+                if (id != -1) {
+                    TypedArray app = context.getTheme().obtainStyledAttributes(id, new int[]{ android.R.attr.textColor, android.R.attr.typeface, android.R.attr.textStyle});
+                    if (app != null){
+                        calenderTextColor = app.getColor(0, 0);
+                        app.recycle();
+                    }
+                } else {
+                    calenderTextColor = typedArray.getColor(R.styleable.CompactCalendarView_compactCalendarTextColor, calenderTextColor);
+                }
+
+                //ColorStateList textColorStateList = typedArray.getColorStateList(R.styleable.CompactCalendarView_compactCalendarTextColor);
                 currentDayBackgroundColor = typedArray.getColor(R.styleable.CompactCalendarView_compactCalendarCurrentDayBackgroundColor, currentDayBackgroundColor);
-                calenderTextColor = typedArray.getColor(R.styleable.CompactCalendarView_compactCalendarTextColor, calenderTextColor);
+
                 currentDayTextColor = typedArray.getColor(R.styleable.CompactCalendarView_compactCalendarCurrentDayTextColor, calenderTextColor);
                 otherMonthDaysTextColor = typedArray.getColor(R.styleable.CompactCalendarView_compactCalendarOtherMonthDaysTextColor, otherMonthDaysTextColor);
                 currentSelectedDayBackgroundColor = typedArray.getColor(R.styleable.CompactCalendarView_compactCalendarCurrentSelectedDayBackgroundColor, currentSelectedDayBackgroundColor);

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -20,7 +20,7 @@
         <attr name="compactCalendarCurrentDayTextColor" format="color"/>
         <attr name="compactCalendarCurrentSelectedDayBackgroundColor" format="color"/>
         <attr name="compactCalendarCurrentSelectedDayTextColor" format="color"/>
-        <attr name="compactCalendarTextColor" format="color"/>
+        <attr name="compactCalendarTextColor" format="reference|color"/>
         <attr name="compactCalendarMultiEventIndicatorColor" format="color"/>
         <attr name="compactCalendarTargetHeight" format="dimension"/>
         <attr name="compactCalendarEventIndicatorStyle"/>


### PR DESCRIPTION
This adds support for those like me who set the textColor through a theme where the color isn't an attribute but a reference to a style that changes based on the currently selected theme.
