### PR TITLE
added the attribute 'disableBackgroundForSelectedDay'

### DIFF
--- a/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarController.java
+++ b/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarController.java
@@ -766,7 +766,7 @@ class CompactCalendarController {
                 boolean isSameDayAsCurrentDay = shouldDrawCurrentDayCircle && (todayDayOfMonth == dayOfMonth) && (eventYear == currentYear);
                 boolean isCurrentSelectedDay = shouldDrawSelectedDayCircle && (selectedDayOfMonth == dayOfMonth);
 
-                if (shouldDrawIndicatorsBelowSelectedDays || (!shouldDrawIndicatorsBelowSelectedDays && !isSameDayAsCurrentDay && !isCurrentSelectedDay) || animationStatus == EXPOSE_CALENDAR_ANIMATION) {
+                if (shouldDrawIndicatorsBelowSelectedDays || (!shouldDrawIndicatorsBelowSelectedDays && !isSameDayAsCurrentDay) || animationStatus == EXPOSE_CALENDAR_ANIMATION) {
                     if (eventIndicatorStyle == FILL_LARGE_INDICATOR || eventIndicatorStyle == NO_FILL_LARGE_INDICATOR) {
                         Event event = eventsList.get(0);
                         drawEventIndicatorCircle(canvas, xPosition, yPosition, event.getColor());
@@ -774,7 +774,7 @@ class CompactCalendarController {
                         yPosition += indicatorOffset;
                         // offset event indicators to draw below selected day indicators
                         // this makes sure that they do no overlap
-                        if (shouldDrawIndicatorsBelowSelectedDays && (isSameDayAsCurrentDay || isCurrentSelectedDay)) {
+                        if (shouldDrawIndicatorsBelowSelectedDays && (isSameDayAsCurrentDay)) {
                             yPosition += indicatorOffset;
                         }
 
@@ -879,10 +879,12 @@ class CompactCalendarController {
             } else {
                 int day = ((dayRow - 1) * 7 + dayColumn + 1) - firstDayOfMonth;
                 int defaultCalenderTextColorToUse = calenderTextColor;
-                if (currentCalender.get(Calendar.DAY_OF_MONTH) == day && isSameMonthAsCurrentCalendar && !isAnimatingWithExpose) {
-                    drawDayCircleIndicator(currentSelectedDayIndicatorStyle, canvas, xPosition, yPosition, currentSelectedDayBackgroundColor);
-                    defaultCalenderTextColorToUse = currentSelectedDayTextColor;
-                } else if (isSameYearAsToday && isSameMonthAsToday && todayDayOfMonth == day && !isAnimatingWithExpose) {
+                // fix by IVleafclover that the selected day is not highlighted
+                // if (currentCalender.get(Calendar.DAY_OF_MONTH) == day && isSameMonthAsCurrentCalendar && !isAnimatingWithExpose) {
+                    // drawDayCircleIndicator(currentSelectedDayIndicatorStyle, canvas, xPosition, yPosition, currentSelectedDayBackgroundColor);
+                    // defaultCalenderTextColorToUse = currentSelectedDayTextColor;
+                // } else
+                if (isSameYearAsToday && isSameMonthAsToday && todayDayOfMonth == day && !isAnimatingWithExpose) {
                     // TODO calculate position of circle in a more reliable way
                     drawDayCircleIndicator(currentDayIndicatorStyle, canvas, xPosition, yPosition, currentDayBackgroundColor);
                     defaultCalenderTextColorToUse = currentDayTextColor;

--- a/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarController.java
+++ b/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarController.java
@@ -78,6 +78,7 @@ class CompactCalendarController {
     private boolean shouldDrawIndicatorsBelowSelectedDays = false;
     private boolean displayOtherMonthDays = false;
     private boolean shouldSelectFirstDayOfMonthOnScroll = true;
+    private boolean disableBackgroundForSelectedDay = false;
 
     private CompactCalendarViewListener listener;
     private VelocityTracker velocityTracker = null;
@@ -234,6 +235,10 @@ class CompactCalendarController {
         calendarWithFirstDayOfMonth.set(Calendar.MINUTE, 0);
         calendarWithFirstDayOfMonth.set(Calendar.SECOND, 0);
         calendarWithFirstDayOfMonth.set(Calendar.MILLISECOND, 0);
+    }
+
+    void disableBackgroundForSelectedDay(boolean disableBackgroundForSelectedDay) {
+        this.disableBackgroundForSelectedDay = disableBackgroundForSelectedDay;
     }
 
     void setShouldSelectFirstDayOfMonthOnScroll(boolean shouldSelectFirstDayOfMonthOnScroll){
@@ -766,7 +771,7 @@ class CompactCalendarController {
                 boolean isSameDayAsCurrentDay = shouldDrawCurrentDayCircle && (todayDayOfMonth == dayOfMonth) && (eventYear == currentYear);
                 boolean isCurrentSelectedDay = shouldDrawSelectedDayCircle && (selectedDayOfMonth == dayOfMonth);
 
-                if (shouldDrawIndicatorsBelowSelectedDays || (!shouldDrawIndicatorsBelowSelectedDays && !isSameDayAsCurrentDay) || animationStatus == EXPOSE_CALENDAR_ANIMATION) {
+                if (shouldDrawIndicatorsBelowSelectedDays || (!shouldDrawIndicatorsBelowSelectedDays && !isSameDayAsCurrentDay && (!isCurrentSelectedDay || disableBackgroundForSelectedDay)) || animationStatus == EXPOSE_CALENDAR_ANIMATION) {
                     if (eventIndicatorStyle == FILL_LARGE_INDICATOR || eventIndicatorStyle == NO_FILL_LARGE_INDICATOR) {
                         Event event = eventsList.get(0);
                         drawEventIndicatorCircle(canvas, xPosition, yPosition, event.getColor());
@@ -774,7 +779,7 @@ class CompactCalendarController {
                         yPosition += indicatorOffset;
                         // offset event indicators to draw below selected day indicators
                         // this makes sure that they do no overlap
-                        if (shouldDrawIndicatorsBelowSelectedDays && (isSameDayAsCurrentDay)) {
+                        if (shouldDrawIndicatorsBelowSelectedDays && (isSameDayAsCurrentDay || (isCurrentSelectedDay && !disableBackgroundForSelectedDay))) {
                             yPosition += indicatorOffset;
                         }
 
@@ -879,12 +884,10 @@ class CompactCalendarController {
             } else {
                 int day = ((dayRow - 1) * 7 + dayColumn + 1) - firstDayOfMonth;
                 int defaultCalenderTextColorToUse = calenderTextColor;
-                // fix by IVleafclover that the selected day is not highlighted
-                // if (currentCalender.get(Calendar.DAY_OF_MONTH) == day && isSameMonthAsCurrentCalendar && !isAnimatingWithExpose) {
-                    // drawDayCircleIndicator(currentSelectedDayIndicatorStyle, canvas, xPosition, yPosition, currentSelectedDayBackgroundColor);
-                    // defaultCalenderTextColorToUse = currentSelectedDayTextColor;
-                // } else
-                if (isSameYearAsToday && isSameMonthAsToday && todayDayOfMonth == day && !isAnimatingWithExpose) {
+                if (currentCalender.get(Calendar.DAY_OF_MONTH) == day && isSameMonthAsCurrentCalendar && !isAnimatingWithExpose && !disableBackgroundForSelectedDay) {
+                    drawDayCircleIndicator(currentSelectedDayIndicatorStyle, canvas, xPosition, yPosition, currentSelectedDayBackgroundColor);
+                    defaultCalenderTextColorToUse = currentSelectedDayTextColor;
+                } else if (isSameYearAsToday && isSameMonthAsToday && todayDayOfMonth == day && !isAnimatingWithExpose) {
                     // TODO calculate position of circle in a more reliable way
                     drawDayCircleIndicator(currentDayIndicatorStyle, canvas, xPosition, yPosition, currentDayBackgroundColor);
                     defaultCalenderTextColorToUse = currentDayTextColor;

--- a/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarView.java
+++ b/library/src/main/java/com/github/sundeepk/compactcalendarview/CompactCalendarView.java
@@ -161,6 +161,10 @@ public class CompactCalendarView extends View {
         return compactCalendarController.getFirstDayOfCurrentMonth();
     }
 
+    public void disableBackgroundForSelectedDay(boolean disableBackgroundForSelectedDay){
+        compactCalendarController.disableBackgroundForSelectedDay(disableBackgroundForSelectedDay);
+    }
+
     public void shouldDrawIndicatorsBelowSelectedDays(boolean shouldDrawIndicatorsBelowSelectedDays){
         compactCalendarController.shouldDrawIndicatorsBelowSelectedDays(shouldDrawIndicatorsBelowSelectedDays);
     }


### PR DESCRIPTION
added the attribute 'disableBackgroundForSelectedDay' to not draw the background circle for the selected day and not interfere with the today background or events on the selected day anymore.

Please cann you add this feature in your new beta/release version?